### PR TITLE
clean up RUNTIME_DIR_PARENT handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,9 @@ CFLAGS ?= -Os -Wall -Wextra -Wpedantic -Wconversion -Werror
 RUNTIME_DIR_PARENT ?= "\"/run/user\""
 
 pam_dumb_runtime_dir.so:
-	$(CC) -o $@ pam_dumb_runtime_dir.c -lpam -shared -fPIC -std=c99 $(CFLAGS) \
-		-DRUNTIME_DIR_PARENT=$(RUNTIME_DIR_PARENT)
+	$(CC) -o $@ pam_dumb_runtime_dir.c -lpam -lpam_misc -shared -fPIC \
+	      -std=c99 $(CFLAGS) -D_GNU_SOURCE \
+	      -DRUNTIME_DIR_PARENT=$(RUNTIME_DIR_PARENT)
 
 .PHONY: all install uninstall clean
 


### PR DESCRIPTION
I build tested this PR from Alpine Linux.

It also includes a few small fixes: it doesn't assume uid_t fits an int, doesn't use the assert to avoid abort()ing from a library, removes an unused header, and uses a trick to at least try to check that the macro RUNTIME_DIR_PARENT is a string although it's a macro so you can ultimately insert any C code you want in there.